### PR TITLE
Return .app path from bundling task

### DIFF
--- a/src/main/scala/de/sciss/sbt/appbundle/AppBundlePlugin.scala
+++ b/src/main/scala/de/sciss/sbt/appbundle/AppBundlePlugin.scala
@@ -42,7 +42,7 @@ object AppBundlePlugin extends Plugin {
 
     val Config            = config("appbundle")
 
-    val appbundle         = TaskKey[Unit]("appbundle")
+    val appbundle         = TaskKey[File]("appbundle")
     val executable        = SettingKey[File]("executable", "Path to the java application stub executable") in Config
     val screenMenu        = SettingKey[Boolean]("screenMenu", "Whether to display the menu bar in the screen top") in Config
     val quartz            = SettingKey[Option[Boolean]]("quartz", "Whether to use the Apple Quartz renderer (true) or the default Java renderer") in Config
@@ -199,7 +199,7 @@ object AppBundlePlugin extends Plugin {
   }
 
   private def appbundleTask(infos: appbundle.InfoSettings, java: appbundle.JavaSettings,
-                            bundle: appbundle.BundleSettings, streams: TaskStreams) {
+                            bundle: appbundle.BundleSettings, streams: TaskStreams): File = {
     import streams.log
     import infos._
     import java._
@@ -409,6 +409,8 @@ object AppBundlePlugin extends Plugin {
 
     // ---- done ----
     log.info("Done bundling.")
+
+    path
 
     // WorkingDirectory (default: $APP_PACKAGE)
 


### PR DESCRIPTION
This allows other tasks to easily locate where the .app folder has been created. Can be useful for example for meta tasks, that depend on the bundle and push it to for example a download server.
